### PR TITLE
Add opts.allowSpaceInLinks to avoid patching tokenizer for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Generates labels and input controls from markdown links like `[text ?input?](nam
 ```sh
 npm install marked-forms
 ```
+## breaking changes
+- As of v3.0.0, this library uses the [`marked.use()`](https://marked.js.org/#/USING_PRO.md#use) plugin api.
+- As of v4.0.0, the plugin globally patches the marked link tokenizer to allow spaces in unbracketed links if
+  `opts.allowSpacesInLinks` is set. The recommended alternative is `[](<link with spaces>)` in pointy brackets.
 
 ## usage
-
-*NOTE: breaking change:*  
-As of v3.0.0, this library uses the [`marked.use()`](https://marked.js.org/#/USING_PRO.md#use) plugin api.  
-The plugin also globally patches the marked link tokenizer to allow spaces in urls.
 
 ```javascript
 var marked = require('marked');
 
 var markedForms = require('marked-forms');
-marked.use(markedForms());
+marked.use(markedForms(opts)); // optional opts { allowSpacesInLinks: true }
 
 var html = marked(markdown);
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ npm install marked-forms
 ```
 ## breaking changes
 - As of v3.0.0, this library uses the [`marked.use()`](https://marked.js.org/#/USING_PRO.md#use) plugin api.
-- As of v4.0.0, the plugin globally patches the marked link tokenizer to allow spaces in unbracketed links if
-  `opts.allowSpacesInLinks` is set. The recommended alternative is `[](<link with spaces>)` in pointy brackets.
+- As of v4.0.0, the plugin will only patch the marked link tokenizer to allow spaces in unbracketed links if
+  `opts.allowSpacesInLinks` is set. The recommended alternative is to use pointy brackets `[](<links with spaces>)`
+  once the [marked](https://github.com/markedjs/marked) library complies with [commonmark](https://spec.commonmark.org/0.29/#link-destination) in this respect.
 
 ## usage
 

--- a/marked-forms.js
+++ b/marked-forms.js
@@ -4,7 +4,7 @@
  * forms-renderer for marked.js
  * generates labels and input controls from [text ?input?](name)
  *
- * usage: marked.use(markedForms())
+ * usage: marked.use(markedForms(opts))
  *
  * copyright 2015-2020, Jürgen Leschner - github.com/jldec - MIT license
  *
@@ -12,19 +12,20 @@
 
 /*eslint no-unused-vars: "off"*/
 
-module.exports = function markedForms() {
+module.exports = function markedForms(opts) {
+  opts = opts || {};
 
   // for state machine used by renderOption
   var listState = { pending:'' };
 
   return {
     renderer: { link:link, listitem:listitem, list:list, paragraph:paragraph },
-    tokenizer: { link: tokenizeLink }
+    tokenizer: opts.allowSpacesInLinks ? { link: tokenizeLink } : {}
   };
 
   //--//--//--//--//--//--//--//--//--//--//
 
-  // patch the link tokenizer regexp on first usage
+  // patch the link tokenizer regexp on first usage (ONLY if opts.allowSpacesInLinks)
   function tokenizeLink(src) {
     if (!this._marked_forms_patched_link_rule) {
       var rules = this.rules.inline;

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "marked-forms",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "generate HTML labels and input controls from markdown",
   "main": "marked-forms.js",
   "dependencies": {},
   "peerDependencies": {
-    "marked": "^1.0.0"
+    "marked": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "marked": "^1.0.0",
+    "marked": "^1.1.0",
     "tape": "^5.0.0"
   },
   "files": [

--- a/test/test-marked-forms.js
+++ b/test/test-marked-forms.js
@@ -12,7 +12,7 @@ var inspect = require('util').inspect;
 var marked = require('marked');
 
 var markedForms = require('../marked-forms');
-marked.use(markedForms());
+marked.use(markedForms({ allowSpacesInLinks:true }));
 
 var tests = [
 
@@ -50,11 +50,11 @@ out:'\n<input name="Name" id="name">' +
 out:'\n<label for="name">Label Text</label>' +
     '\n<input name="Name" id="name">'}
 ,
-{in:'[?? Label Text](<Name With Spaces>)',
+{in:'[?? Label Text](Name With Spaces)',
 out:'\n<input name="Name With Spaces" id="name-with-spaces">' +
     '\n<label for="name-with-spaces">Label Text</label>'}
 ,
-{in:'[Label Text ??](<Name With Spaces>)',
+{in:'[Label Text ??](Name With Spaces)',
 out:'\n<label for="name-with-spaces">Label Text</label>' +
     '\n<input name="Name With Spaces" id="name-with-spaces">'}
 ,
@@ -417,7 +417,7 @@ out:'\n<label for="name" class="classname1 classname2">Label text</label>'}
 {in:'[?label? Label text](- "classname1 classname2")',
 out:'\n<label class="classname1 classname2">Label text</label>'}
 ,
-{in:'[Label text ?label?](<name with spaces> "classname1 classname2")',
+{in:'[Label text ?label?](name with spaces "classname1 classname2")',
 out:'\n<label for="name-with-spaces" class="classname1 classname2">Label text</label>'}
 ,
 {in:'[?checkbox?*X Label Text](name)',

--- a/test/test-marked-forms.js
+++ b/test/test-marked-forms.js
@@ -50,11 +50,11 @@ out:'\n<input name="Name" id="name">' +
 out:'\n<label for="name">Label Text</label>' +
     '\n<input name="Name" id="name">'}
 ,
-{in:'[?? Label Text](Name With Spaces)',
+{in:'[?? Label Text](<Name With Spaces>)',
 out:'\n<input name="Name With Spaces" id="name-with-spaces">' +
     '\n<label for="name-with-spaces">Label Text</label>'}
 ,
-{in:'[Label Text ??](Name With Spaces)',
+{in:'[Label Text ??](<Name With Spaces>)',
 out:'\n<label for="name-with-spaces">Label Text</label>' +
     '\n<input name="Name With Spaces" id="name-with-spaces">'}
 ,
@@ -417,7 +417,7 @@ out:'\n<label for="name" class="classname1 classname2">Label text</label>'}
 {in:'[?label? Label text](- "classname1 classname2")',
 out:'\n<label class="classname1 classname2">Label text</label>'}
 ,
-{in:'[Label text ?label?](name with spaces "classname1 classname2")',
+{in:'[Label text ?label?](<name with spaces> "classname1 classname2")',
 out:'\n<label for="name-with-spaces" class="classname1 classname2">Label text</label>'}
 ,
 {in:'[?checkbox?*X Label Text](name)',


### PR DESCRIPTION
The existing plugin globally patches the marked link tokenizer to allow spaces in unbracketed links.

It would be preferable if this patch were optional (for backward compatibility) and encourage new users to adopt `[](<link with spaces>)` in pointy brackets.

todo:
- [x] add opt.allowSpaceInLinks
- [x] use opts.allowSpaceInLinks in existing tests
- [ ] _defer_: add new tests without opts.allowSpaceInLinks